### PR TITLE
Updated Expiration to UTC for c-sharp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Libraries used for authenticating to [Webtrends Streams](http://webtrends.com/so
 [Example](https://github.com/Webtrends/Streams-OAuth-Libraries/blob/master/ruby/example.rb)
 (Note: Requires Json and HTTParty rubygems)
 
+### C-sharp
+[Example](https://github.com/Webtrends/Streams-OAuth-Libraries/blob/master/csharp/Example.cs)
+(Note: Requires Newtonsoft.json and RestSharp nuget packages)
 
 Legal
 -----------------------

--- a/csharp/TokenRequest.cs
+++ b/csharp/TokenRequest.cs
@@ -39,7 +39,7 @@ public class TokenRequest
             Issuer = clientId,
             Principal = clientId,
             Audience = audience,
-            Expiration = DateTime.Now.AddSeconds(30),
+            Expiration = DateTime.Now.ToUniversalTime().AddSeconds(30),
             Scope = scope
         };
 


### PR DESCRIPTION
Executing this code in minus timezones gives back "Bad Request", where as in plus timezones, the Expiration is too long allowing for MITM attacks
